### PR TITLE
[Fix] - Use bash to install Miniconda

### DIFF
--- a/.github/workflows/helpers/install_dependencies.sh
+++ b/.github/workflows/helpers/install_dependencies.sh
@@ -18,7 +18,7 @@ CUDA_VERSION=${CUDA_VERSION:-11.1.1}
 echo "Installing Miniconda..."
 wget -c -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     chmod +x ./Miniconda3-latest-Linux-x86_64.sh && \
-    ./Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
     rm ./Miniconda3-latest-Linux-x86_64.sh && \
     /opt/conda/bin/conda upgrade --all && \
     /opt/conda/bin/conda install conda-build conda-verify && \


### PR DESCRIPTION
Attempting to fix the build failure
Related issue: https://github.com/ContinuumIO/anaconda-issues/issues/13110